### PR TITLE
Fix HUMANS Lab entry: correct lab name and use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ Koç University, TUR
 - [People, Space, and Algorithms (PSA) Research Group](https://www.psagroup.org/), Northwestern University, Evanston, USA
 - [Science of Networks in Communities (SONIC) Lab](https://sonic.northwestern.edu/), Northwestern University, Evanston, USA
 - [Center for AI in Society(CAIS)](https://cais.usc.edu/), University of Southern California, Los Angeles, USA
-- [HUmans | MAchines | Networks | Society Lab (HUMANS)](http://www.emilio.ferrara.name/), University of Southern California, Los Angeles, USA
+- [HUmans | MAchines | Networks | Social Systems Lab (HUMANS)](https://www.emilio.ferrara.name/), University of Southern California, Los Angeles, USA
 - [Computational Social Science Institute at UMass](https://www.cssi.umass.edu), Massachusetts Amherst, USA
 - [Computational Social Science Lab](https://csslab.rutgers.edu/), Rutgers University, New Brunswick, USA
 - [Working Group on Computational Social Science](https://datascience.columbia.edu/research/groups/computational-social-science/), Columbia University, New York, USA


### PR DESCRIPTION
Small correction to an existing entry under **Research Groups**.

Two issues with the current line:

1. The lab name is given as "HUmans | MAchines | Networks | **Society** Lab". The lab's actual name is "HUmans | MAchines | Networks | **Social Systems**" — as used on its own site and in the site title.
2. The link uses `http://`, which 301-redirects to `https://`. Pointing at https directly saves the redirect.

No new entry is added and nothing is promoted — this only corrects the text and link of a line already in the list.

**Disclosure:** I direct this lab, so I am flagging the connection explicitly given the guideline against using the list for self-promotion. Happy to close this if a correction from the subject of an entry is unwelcome.